### PR TITLE
remove gpu_utilization()

### DIFF
--- a/ts/metrics/system_metrics.py
+++ b/ts/metrics/system_metrics.py
@@ -57,6 +57,8 @@ def collect_gpu_metrics(num_of_gpus):
     :param num_of_gpus: Total number of available GPUs.
     :return:
     """
+    if num_of_gpus <= 0:
+        return
     for gpu_index in range(num_of_gpus):
         if torch.version.cuda:
             free, total = torch.cuda.mem_get_info(gpu_index)
@@ -105,27 +107,6 @@ def collect_gpu_metrics(num_of_gpus):
         )
 
 
-def gpu_utilization(num_of_gpus):
-    """
-    Generic GPU utilization function that supports NVIDIA and AMD GPUs.
-    :param num_of_gpu: Total number of available GPUs.
-    :return:
-    """
-    if num_of_gpus <= 0:
-        return
-
-    if torch.cuda.is_available() and not (torch.version.cuda or torch.version.hip):
-        logging.error("No supported GPU detected.")
-        return
-
-    if torch.cuda.is_available() and torch.version.cuda:
-        logging.info("Collecting NVIDIA GPU metrics...")
-    elif torch.cuda.is_available() and torch.version.hip:
-        logging.info("Collecting AMD GPU metrics...")
-
-    collect_gpu_metrics(num_of_gpus)
-
-
 def collect_all(mod, num_of_gpus):
     """
     Collect all system metrics.
@@ -141,7 +122,7 @@ def collect_all(mod, num_of_gpus):
             "collect_all",
             "collect_gpu_metrics",
         ):
-            if value.__name__ == "gpu_utilization":
+            if value.__name__ == "collect_gpu_metrics":
                 value(num_of_gpus)
             else:
                 value()


### PR DESCRIPTION
closes #11 

`MetricCollector.java` parses the output from `system_metrics.py` which outputs the metrics using `logging.info()`. This very unfortunate design choice tripped things up when we used the logging function for it's intended purpose. I removed our added calls to `logging.info()` to remove the problem.

tested by building a rocm-enabled docker image on a AMD gpu node with `DOCKER_BUILDKIT=1 docker build  --build-arg ROCM_VERSION=rocm61 --build-arg MACHINE_TYPE=gpu --build-arg BASE_IMAGE=ubuntu:24.04  --build-arg PYTHON_VERSION=3.9  -t anders-testing -f ./docker/Dockerfile.anders .`

and running 

`docker run --device=/dev/kfd --device=/dev/dri -e JAVA_TOOL_OPTIONS="-Dlogging.level.root=DEBUG" -e HIP_VISIBLE_DEVICES=6 -e PYTHONLOG=DEBUG -it anders-testing`


which give us the expected output without the error message

```
Picked up JAVA_TOOL_OPTIONS: -Dlogging.level.root=DEBUG
WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.
2024-11-20T13:01:00,434 [WARN ] main org.pytorch.serve.util.ConfigManager - Your torchserve instance can access any URL to load models. When deploying to production, make sure to limit the set of allowed_urls in config.properties
2024-11-20T13:01:00,455 [INFO ] main org.pytorch.serve.servingsdk.impl.PluginsManager - Initializing plugins manager...
2024-11-20T13:01:00,508 [INFO ] main org.pytorch.serve.metrics.configuration.MetricConfiguration - Successfully loaded metrics configuration from /home/venv/lib/python3.9/site-packages/ts/configs/metrics.yaml
2024-11-20T13:01:00,776 [INFO ] main org.pytorch.serve.ModelServer -
Torchserve version: 0.12.0
TS Home: /home/venv/lib/python3.9/site-packages
Current directory: /home/model-server
Temp directory: /home/model-server/tmp
Metrics config path: /home/venv/lib/python3.9/site-packages/ts/configs/metrics.yaml
Number of GPUs: 1
Number of CPUs: 128
Max heap size: 30688 M
Python executable: /home/venv/bin/python
Config file: /home/model-server/config.properties
Inference address: http://0.0.0.0:8080
Management address: http://0.0.0.0:8081
Metrics address: http://0.0.0.0:8082
Model Store: /home/model-server/model-store
Initial Models: N/A
Log dir: /home/model-server/logs
Metrics dir: /home/model-server/logs
Netty threads: 32
Netty client threads: 0
Default workers per model: 1
Blacklist Regex: N/A
Maximum Response Size: 6553500
Maximum Request Size: 6553500
Limit Maximum Image Pixels: true
Prefer direct buffer: false
Allowed Urls: [file://.*|http(s)?://.*]
Custom python dependency for model allowed: false
Enable metrics API: true
Metrics mode: LOG
Disable system metrics: false
Workflow Store: /home/model-server/wf-store
CPP log config: N/A
Model config: N/A
System metrics command: default
Model API enabled: false
2024-11-20T13:01:00,785 [INFO ] main org.pytorch.serve.servingsdk.impl.PluginsManager -  Loading snapshot serializer plugin...
2024-11-20T13:01:00,798 [INFO ] main org.pytorch.serve.ModelServer - Initialize Inference server with: EpollServerSocketChannel.
2024-11-20T13:01:00,857 [INFO ] main org.pytorch.serve.ModelServer - Inference API bind to: http://0.0.0.0:8080
2024-11-20T13:01:00,858 [INFO ] main org.pytorch.serve.ModelServer - Initialize Management server with: EpollServerSocketChannel.
2024-11-20T13:01:00,859 [INFO ] main org.pytorch.serve.ModelServer - Management API bind to: http://0.0.0.0:8081
2024-11-20T13:01:00,859 [INFO ] main org.pytorch.serve.ModelServer - Initialize Metrics server with: EpollServerSocketChannel.
2024-11-20T13:01:00,860 [INFO ] main org.pytorch.serve.ModelServer - Metrics API bind to: http://0.0.0.0:8082
Model server started.
2024-11-20T13:01:02,441 [INFO ] pool-3-thread-1 TS_METRICS - CPUUtilization.Percent:8.7|#Level:Host|#hostname:97a8e2e2437a,timestamp:1732107662
```